### PR TITLE
emit `error` event instead of throw error

### DIFF
--- a/lib/ConnectionManager.js
+++ b/lib/ConnectionManager.js
@@ -480,20 +480,22 @@ ConnectionManager.prototype.onSocketData = function (buffer) {
             if (!pendingPacket) {
                 // TODO, better error handling and logging  need to be done.
                 // Need to clean up and do a reconnect.
-                throw new Error(
+                self.emit('error', new Error(
                     'Nothing in pending queue but got data from server.'
-                );
+                ));
+                return;
             }
 
             if (pendingPacket.request.header.xid !== responseHeader.xid) {
                 // TODO, better error handling/logging need to bee done here.
                 // Need to clean up and do a reconnect.
-                throw new Error(
+                self.emit('error', new Error(
                     'Xid out of order. Got xid: ' +
                         responseHeader.xid + ' with error code: ' +
                         responseHeader.err + ', expected xid: ' +
                         pendingPacket.request.header.xid + '.'
-                );
+                ));
+                return;
             }
 
             if (responseHeader.zxid) {
@@ -540,8 +542,9 @@ ConnectionManager.prototype.onSocketData = function (buffer) {
                     responsePayload = new jute.TransactionResponse();
                     break;
                 default:
-                    throw new Error('Unknown request OP_CODE: ' +
-                        pendingPacket.request.header.type);
+                    self.emit('error', new Error('Unknown request OP_CODE: ' +
+                        pendingPacket.request.header.type));
+                    return;
                 }
 
                 if (responsePayload) {


### PR DESCRIPTION
I think just emit `error` event is better than throw it on `ConnectionManager.prototype.onSocketData()`.

When network come wrong, the zk response data will fault. And `node-zookeeper-client` throw error when data format incorrect, it will let node process exit.

I think use `error` event is better. If use care about `error`, he will listen the `error` event and reconnect zk server again.

@see alibaba/node-hbase-client#22
