### PR TITLE
Add retry support for connection loss exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,15 @@ Factory method to create a new zookeeper [client](#client) instance.
 
     * `sessionTimeout` Session timeout in milliseconds, defaults to 30 seconds.
     * `spinDelay` The delay (in milliseconds) between each connection attempts.
+    * `retries` The number of retry attempts for connection loss exception.
 
   Defaults options:
 
     ```javascript
     {
         sessionTimeout: 30000,
-        spinDelay : 1000
+        spinDelay : 1000,
+        retries : 0
     }
     ```
 

--- a/examples/acl.js
+++ b/examples/acl.js
@@ -7,7 +7,7 @@
 
 var zookeeper = require('../index.js');
 
-var client = zookeeper.createClient(process.argv[2]);
+var client = zookeeper.createClient(process.argv[2], { retries : 2 });
 var path = process.argv[3];
 var acls = [
     new zookeeper.ACL(

--- a/examples/create.js
+++ b/examples/create.js
@@ -7,7 +7,7 @@
 
 var zookeeper = require('../index.js');
 
-var client = zookeeper.createClient(process.argv[2]);
+var client = zookeeper.createClient(process.argv[2], { retries : 2 });
 var path = process.argv[3];
 
 client.once('connected', function () {

--- a/examples/delete.js
+++ b/examples/delete.js
@@ -7,7 +7,7 @@
 
 var zookeeper = require('../index.js');
 
-var client = zookeeper.createClient(process.argv[2]);
+var client = zookeeper.createClient(process.argv[2], { retries : 2 });
 var path = process.argv[3];
 
 client.on('connected', function (state) {

--- a/examples/exists.js
+++ b/examples/exists.js
@@ -7,7 +7,7 @@
 
 var zookeeper = require('../index.js');
 
-var client = zookeeper.createClient(process.argv[2]);
+var client = zookeeper.createClient(process.argv[2], { retries : 2 });
 var path = process.argv[3];
 
 function exists(client, path) {

--- a/examples/get.js
+++ b/examples/get.js
@@ -7,7 +7,7 @@
 
 var zookeeper = require('../index.js');
 
-var client = zookeeper.createClient(process.argv[2]);
+var client = zookeeper.createClient(process.argv[2], { retries : 2 });
 var path = process.argv[3];
 
 function getData(client, path) {

--- a/examples/list.js
+++ b/examples/list.js
@@ -7,7 +7,7 @@
 
 var zookeeper = require('../index.js');
 
-var client = zookeeper.createClient(process.argv[2]);
+var client = zookeeper.createClient(process.argv[2], { retries : 2 });
 var path = process.argv[3];
 
 function listChildren(client, path) {

--- a/examples/set.js
+++ b/examples/set.js
@@ -7,7 +7,7 @@
 
 var zookeeper = require('../index.js');
 
-var client = zookeeper.createClient(process.argv[2]);
+var client = zookeeper.createClient(process.argv[2], { retries : 2 });
 var path = process.argv[3];
 var data = new Buffer(process.argv[4]);
 
@@ -26,6 +26,7 @@ client.once('connected', function () {
             path,
             stat.version
         );
+        client.close();
     });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-zookeeper-client",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A pure Javascript ZooKeeper client for Node.js.",
   "author": "Alex Guan <alex.guan@gmail.com>",
   "main": "index.js",


### PR DESCRIPTION
A new option: `retries` is introduced to the `createClient` method. The default value is `0`, which disables the retry behavior.

If the value is greater than 0, when connection loss exception is caught, the client will automatically retry the operation with exponentially back-off.
