### PR TITLE
Fix chrootPath setting when connectionString has multiple servers listed

### DIFF
--- a/lib/ConnectionStringParser.js
+++ b/lib/ConnectionStringParser.js
@@ -42,7 +42,12 @@ function ConnectionStringParser(connectionString) {
         servers = [];
 
     if (index !== -1 && index !== (connectionString.length - 1)) {
-        this.chrootPath = connectionString.substring(index);
+        var sepIndex = connectionString.indexOf(',');
+        if (sepIndex !== -1) {
+            this.chrootPath = connectionString.substring(index, sepIndex);
+        } else {
+            this.chrootPath = connectionString.substring(index);
+        }
         Path.validate(this.chrootPath);
     } else {
         this.chrootPath = undefined;


### PR DESCRIPTION
The 'chrootPath' was being set to everything past the first '/' in the connections string. This included all other servers listed in the connection string. For example, with a connection string like:

server:1234/chroot,server2:2345/chroot,server3:3456/chroot

the 'chrootPath' would be set to 'chroot,server2:2345/chroot,server3:3456/chroot' instead of just 'chroot'. This commit checks to see if there are any separators in the connection string, namely a comma, and if so, take the substring up until that first separator instead of the entire rest of the string.
