### PR TITLE
Fix problem where duplicate watchers are not detected.

### DIFF
--- a/lib/WatcherManager.js
+++ b/lib/WatcherManager.js
@@ -30,7 +30,7 @@ function registerWatcher(self, type, path, watcher) {
     watcherExists = watchers[path].listeners('notification').some(function (l) {
         // This is rather hacky since node.js wraps the listeners using an
         // internal function.
-        return l === watcher || l.listener === watcher;
+        return l === watcher || l.listener === watcher || l.toString() === watcher.toString() || (l.listener && l.listener.toString() === watcher.toString());
     });
 
     if (!watcherExists) {


### PR DESCRIPTION
I was having a problem where node complained about too many listeners.  Eventually a co-worker helped me track it to this comparison.  To properly compare functions which may be (probably are) anonymous, the toString() method is required.  I used this article to confirm this idea: http://stackoverflow.com/questions/21334835/how-do-you-compare-anonymous-functions-in-javascript.  The attached fix resolved the issue by properly identifying watcher functions that were the same.
