### PR TITLE
Remove path from watch list once watch fires; fixes #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.2
+
+1. [Issue #31: WatcherManager leaks memory on un-rewatched nodes](https://github.com/alexguan/node-zookeeper-client/issues/31)
+
 ## 0.2.1
 
 1. [Issue #19: Prevent duplicated watcher from being added](https://github.com/alexguan/node-zookeeper-client/pull/19)

--- a/lib/WatcherManager.js
+++ b/lib/WatcherManager.js
@@ -88,23 +88,28 @@ WatcherManager.prototype.emit = function (watcherEvent) {
     case Event.NODE_CREATED:
         if (this.dataWatchers[watcherEvent.path]) {
             emitters.push(this.dataWatchers[watcherEvent.path]);
+            delete this.dataWatchers[watcherEvent.path];
         }
 
         if (this.existenceWatchers[watcherEvent.path]) {
             emitters.push(this.existenceWatchers[watcherEvent.path]);
+            delete this.existenceWatchers[watcherEvent.path];
         }
         break;
     case Event.NODE_CHILDREN_CHANGED:
         if (this.childWatchers[watcherEvent.path]) {
             emitters.push(this.childWatchers[watcherEvent.path]);
+            delete this.childWatchers[watcherEvent.path];
         }
         break;
     case Event.NODE_DELETED:
         if (this.dataWatchers[watcherEvent.path]) {
             emitters.push(this.dataWatchers[watcherEvent.path]);
+            delete this.dataWatchers[watcherEvent.path];
         }
         if (this.childWatchers[watcherEvent.path]) {
             emitters.push(this.childWatchers[watcherEvent.path]);
+            delete this.childWatchers[watcherEvent.path];
         }
         break;
     default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-zookeeper-client",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A pure Javascript ZooKeeper client for Node.js.",
   "author": "Alex Guan <alex.guan@gmail.com>",
   "main": "index.js",


### PR DESCRIPTION
This makes us match the behavior of the canonical Java client,
and stops leaking EventEmitters for nodes that aren't being watched
anymore.