### PR TITLE
Add SESSION_MOVED exception code

### DIFF
--- a/lib/Exception.js
+++ b/lib/Exception.js
@@ -30,7 +30,8 @@ var CODES = {
     SESSION_EXPIRED : -112,
     INVALID_CALLBACK : -113,
     INVALID_ACL : -114,
-    AUTH_FAILED : -115
+    AUTH_FAILED : -115,
+    SESSION_MOVED: -118
 };
 
 /**


### PR DESCRIPTION
Following ZooKeeper documentation this is extremely rare exception client can get but still it can get it, so it's worth adding to client