### PR TITLE
Add code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ node_js:
   - "6"
   - "5"
   - "4"
-
+after_success:
+  - "npm run coverage"
+  - "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A pure Javascript [ZooKeeper](http://zookeeper.apache.org) client module for
 
 [![Build Status](https://travis-ci.org/alexguan/node-zookeeper-client.png?branch=master)](https://travis-ci.org/alexguan/node-zookeeper-client)
 
+[![Coverage Status](https://coveralls.io/repos/github/alexguan/node-zookeeper-client/badge.svg?branch=master)](https://coveralls.io/github/alexguan/node-zookeeper-client?branch=master)
+
 This module is designed to resemble the ZooKeeper Java client API but with
 tweaks to follow the convention of Node.js modules. Developers that are familiar
 with the ZooKeeper Java client would be able to pick it up quickly.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "devDependencies": {
     "chai": "~1.5.0",
+    "coveralls": "^2.11.12",
     "eslint": "^3.2.0",
     "istanbul": "~0.1.34",
     "mocha": "~1.9.0"


### PR DESCRIPTION
Adds code coverage reporting using [Coveralls](https://coveralls.io/). This uses the existing code coverage tools, it just adds a final step to Travis CI to report the `lcov.info` information to coveralls on success.

To see what the coveralls tool will look like, you can [see my fork](https://coveralls.io/github/lightswitch05/node-zookeeper-client).

By default, all pull requests are commented on with their code coverage. [Here is an example](https://github.com/lightswitch05/node-zookeeper-client/pull/3). This behavior can be disabled.

Note: To enable coveralls integration with this original repo, it does require you to log into coveralls.io and allow github integration. The account is free, but I understand if that isn't something you want.
