### PR TITLE
Expose `Client` class too

### DIFF
--- a/index.js
+++ b/index.js
@@ -908,6 +908,7 @@ function createClient(connectionString, options) {
 }
 
 exports.createClient = createClient;
+exports.Client = Client;
 exports.ACL = ACL;
 exports.Id = Id;
 exports.Permission = Permission;

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     }
   ],
   "devDependencies": {
+    "mocha": "~1.9.0",
     "chai": "~1.5.0",
     "istanbul": "~0.1.34",
-    "jslint": "^0.10.3",
-    "mocha": "~1.9.0"
+    "jslint": "~0.1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     }
   ],
   "devDependencies": {
-    "mocha": "~1.9.0",
     "chai": "~1.5.0",
     "istanbul": "~0.1.34",
-    "jslint": "~0.1.9"
+    "jslint": "^0.10.3",
+    "mocha": "~1.9.0"
   }
 }


### PR DESCRIPTION
In some case, I need to access the `Client` class. 
e.g I need to promisify the `Client.prototype` to add some `fooAsync` method to utilize Promise & co/async/await. 

So we need expose Client too. Any Consideration to drop node<4 support & use es6 class to implement stuff?