### PR TITLE
Don't clear connectTimeout until ConnectResponse is received

### DIFF
--- a/lib/ConnectionManager.js
+++ b/lib/ConnectionManager.js
@@ -303,10 +303,6 @@ ConnectionManager.prototype.onSocketConnected = function () {
         header,
         payload;
 
-    if (this.connectTimeoutHandler) {
-        clearTimeout(this.connectTimeoutHandler);
-    }
-
     connectRequest = new jute.Request(null, new jute.protocol.ConnectRequest(
         jute.PROTOCOL_VERSION,
         this.zxid,
@@ -428,6 +424,9 @@ ConnectionManager.prototype.onSocketData = function (buffer) {
         connectResponse = new jute.protocol.ConnectResponse();
         offset += connectResponse.deserialize(buffer, offset);
 
+        if (this.connectTimeoutHandler) {
+            clearTimeout(this.connectTimeoutHandler);
+        }
 
         if (connectResponse.timeOut <= 0) {
             self.setState(STATES.SESSION_EXPIRED);


### PR DESCRIPTION
Otherwise we leave a window between when the TCP connection emits 'connect' and we send the ConnectRequest, and when the ConnectResponse comes back, when we have no timeout applying at all and will make no attempt to talk to the socket again.

If we get netsplit from ZK during such a window (and stay netsplit for long enough to both go past the ZK session timeout, and then miss any of its OS' FIN retransmits, which may only be a few minutes), we may hang in the CONNECTING state indefinitely, never reconnecting.

Since the OS on the ZK side has given up on the socket and forgotten about it (its FINs/RSTs never got through during the netsplit), the only way our local OS could find out about the issue is if we tried to send data (then the remote side would send RST back), which we will not do (since we haven't got the ConnectResponse yet or set up the ping timeout).

This window of time may sound small, but sometimes a heavily loaded ZK (such as when it's in the middle of dealing with, say, a netsplit in the cluster) can take quite a long time between when its host OS ACKs the ConnectRequest we sent, and when it then tries to send a ConnectResponse. We've seen windows in prod here of up to almost 1 sec.

We've hit this bug in prod repeatedly during widespread network events (e.g. switch fabric reconfiguration). I can also reproduce it reliably in the lab by making the ZK connect sequence artificially slow (adding a sleep) and starting a netsplit at the right time.