### PR TITLE
Fixes #64: linting issue with SPECIFICATION_FILE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ coverage
 
 node_modules
 npm-debug.log
+
+yarn.lock

--- a/lib/jute/index.js
+++ b/lib/jute/index.js
@@ -19,7 +19,6 @@ var exports = module.exports;
 var jute = exports;
 
 // Constants.
-var SPECIFICATION_FILE = './specification.json';
 var PROTOCOL_VERSION = 0;
 
 var OP_CODES = {
@@ -766,7 +765,7 @@ exports.TransactionRequest = TransactionRequest;
 exports.TransactionResponse = TransactionResponse;
 
 // Automatically generates and exports all protocol and data classes.
-var specification = require(SPECIFICATION_FILE);
+var specification = require('./specification.json');
 
 Object.keys(specification).forEach(function (moduleName) {
     // Modules like protocol or data.


### PR DESCRIPTION
No need to use a const for the `require`, as it's an anti-pattern and violates of [linting rules](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md) targeting dynamic imports.

Original issue surfaced from using webpack to package an app that has a transitive dependency on this library via `kafka-node`.