### PR TITLE
Support promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This module has been tested to work with ZooKeeper version 3.4.*.
         + [getPath](#string-getpath)
         + [getName](#string-getname)
         + [toString](#string-tostring)
-    + [Exception](#exception)
++ [Promise](#promise)
 + [Dependency](#dependency)
 + [License](#license)
 
@@ -858,12 +858,40 @@ Return the exception name as defined in aforementioned list.
 
 ---
 
-### String toString()
+#### String toString()
 
 Return the exception in a readable string.
 
 ---
 
+## Promise
+
+Several methods are optional promisified.
+
+- Client.create
+- Client.remove
+- Client.exists
+- Client.getChildren
+- Client.getData
+- Client.setData
+- Client.getACL
+- Client.setACL
+- Transaction.commit
+
+All methods above will return a promise if they fail to receive a callback function as the last parameter.
+
+### Example
+
+```javascript
+zookeeper.create('/a', Buffer.from('hello'))
+    .then((path) => {
+        assert(path === '/a');
+    }, (err) => {
+        console.log(err);
+    });
+```
+
+---
 
 ## Dependency
 

--- a/index.js
+++ b/index.js
@@ -78,26 +78,28 @@ function defaultStateListener(state) {
  * @returns {Promise}
  */
 function whilst(a, b, getResult, callback) {
-    if (typeof callback === 'function') {
-        async.whilst(a, b, function(err) {
-            var args = [],
-                result = getResult();
-            args.push(result.error);
-            Array.prototype.push.apply(args, result.args);
+    var resolve, reject;
+    async.whilst(a, b, function() {
+        var args = [],
+            result = getResult();
+        args.push(result.error);
+        Array.prototype.push.apply(args, result.args);
+        if (callback) {
             callback.apply(null, args);
-        });
-        return;
-    }
-    return new Promise(function(resolve, reject) {
-        async.whilst(a, b, function() {
-            var result = getResult();
-            if (result.error) {
-                reject(result.error);
-                return;
-            }
+            return;
+        }
+        if (result.error) {
+            reject(result.error);
+        } else {
             resolve.apply(null, result.args);
-        });
+        }
     });
+    if (!callback) {
+        return new Promise(function(a, b) {
+            resolve = a;
+            reject = b;
+        });
+    }
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ function defaultStateListener(state) {
 }
 
 /**
+ * Only used in attempt function
  * @private
  * @param a {Function}
  * @param b {Function}
@@ -85,8 +86,7 @@ function whilst(a, b, getResult, callback) {
             Array.prototype.push.apply(args, result.args);
             callback.apply(null, args);
         });
-        // always return a promise
-        return Promise.resolve();
+        return;
     }
     return new Promise(function(resolve, reject) {
         async.whilst(a, b, function() {
@@ -188,7 +188,8 @@ function attempt(self, fn, callback) {
         },
         function () {
             return results[count - 1];
-        }
+        },
+        callback
     );
 }
 

--- a/lib/Transaction.js
+++ b/lib/Transaction.js
@@ -166,22 +166,23 @@ Transaction.prototype.remove = function (path, version) {
  * Execute the transaction atomically.
  *
  * @method commit
- * @param callback {Function} callback function.
+ * @param callback {[Function]} callback function.
+ * @returns {Promise} return promise if callback is not provided
  */
 Transaction.prototype.commit = function (callback) {
-    assert(typeof callback === 'function', 'callback must be a function');
-
     var self = this,
         header = new jute.protocol.RequestHeader(),
         payload = new jute.TransactionRequest(this.ops),
-        request;
+        request,
+        resolve,
+        reject;
 
     header.type = jute.OP_CODES.MULTI;
     request = new jute.Request(header, payload);
 
     this.connectionManager.queue(request, function (error, response) {
         if (error) {
-            callback(error);
+            callback ? callback(error): reject(error);
             return;
         }
 
@@ -199,8 +200,15 @@ Transaction.prototype.commit = function (callback) {
             }
         }
 
-        callback(error, response.payload.results);
+        callback ? callback(error, response.payload.results) : resolve(response.payload.results);
     });
+
+    if (!callback) {
+        return new Promise(function (a, b) {
+            resolve = a;
+            reject = b;
+        });
+    }
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-zookeeper-client",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "A pure Javascript ZooKeeper client for Node.js.",
   "author": "Alex Guan <alex.guan@gmail.com>",
   "main": "index.js",


### PR DESCRIPTION
This is a nice zookeeper library. However, compared to promise, the callback style is not coding friendly today. Some issues or pull requests are related to promise API. For example, #47 #58 #87 .

I have made the following methods promise supported.

- Client.create
- Client.remove
- Client.exists
- Client.getChildren
- Client.getData
- Client.setData
- Client.getACL
- Client.setACL
- Transaction.commit

Example

```javascript
zookeeper.create('/a', Buffer.from('hello'))
    .then((path) => {
        assert(path === '/a');
    }, (err) => {
        console.log(err);
    });
```

This PR does not add new methods and backward compatible. In general, the methods above will return a promise if they fail to receive a callback function as the last parameter.