### PR TITLE
Optionally enable TLS connection

### DIFF
--- a/lib/ConnectionManager.js
+++ b/lib/ConnectionManager.js
@@ -6,6 +6,7 @@
  */
 
 var net = require('net');
+var tls = require('tls');
 var utils = require('util');
 var events = require('events');
 
@@ -217,7 +218,9 @@ ConnectionManager.prototype.connect = function () {
     self.setState(STATES.CONNECTING);
 
     self.findNextServer(function (server) {
-        self.socket = net.connect(server);
+        self.socket = (self.options.tls === undefined)
+            ? net.connect(server)
+            : tls.connect(server, self.options.tls);
 
         self.connectTimeoutHandler = setTimeout(
             self.onSocketConnectTimeout.bind(self),


### PR DESCRIPTION
Adds the possibility to use a tls socket instead of net socket instance,
if a tls connection is desired.