### PR TITLE
Change xid computation logic

### DIFF
--- a/lib/ConnectionManager.js
+++ b/lib/ConnectionManager.js
@@ -614,8 +614,8 @@ ConnectionManager.prototype.onPacketQueueReadable = function () {
                 header.type !== jute.OP_CODES.PING &&
                 header.type !== jute.OP_CODES.AUTH) {
 
+            this.xid = (this.xid % 2147483647) + 1;
             header.xid = this.xid;
-            this.xid += 1;
 
             // Only put requests that are not connect, ping and auth into
             // the pending queue.


### PR DESCRIPTION
Zookeeper doesn't handle xid = 0 properly, so change logic to start xid from 1 and properly handle integer overflow

see #100 for detailed explanation